### PR TITLE
fix: Downgrade `video_player` Dependency to v2.3.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   flutter_cache_manager: ^3.3.1
   rxdart: ^0.27.7
-  video_player: ^2.8.2
+  video_player: 2.3.5
   collection: ^1.18.0
 
 dev_dependencies:


### PR DESCRIPTION
- Updated the `video_player` package in pubspec.yaml from version 2.8.2 to 2.3.5.
- The change aligns with our SDK requirements, which rely on version 2.3.5 of the `video_player` package.